### PR TITLE
changed wrong appbar displaying in referee's and repoter's pages

### DIFF
--- a/client/src/routes/MatchPage.jsx
+++ b/client/src/routes/MatchPage.jsx
@@ -8,6 +8,8 @@ import { AuthContext } from "../context/authContext";
 import UserFinder from "../apis/UserFinder";
 import ReporterMatch from "../components/RatingComponents/ReporterMatch.component";
 import { CircularProgress } from "@material-ui/core";
+import RefAppBar from "../components/RetiredRefReporterAppBar";
+
 
 const MatchPage = () => {
   const navigate = useNavigate();
@@ -63,10 +65,19 @@ const MatchPage = () => {
       </div>
     );
   }
-  else if(user.role == "TFF Admin" || user.role == "Reporter" || user.role == "Retired Referee"){
+  else if(user.role == "TFF Admin"){
     return (
       <div>
         <ResponsiveAppBar/>
+        <ReporterMatch/>
+        <Copyright sx={{ mt: 5 }} />
+      </div>
+    );
+  }
+  else if(user.role == "Reporter" || user.role == "Retired Referee"){
+    return (
+      <div>
+        <RefAppBar/>
         <ReporterMatch/>
         <Copyright sx={{ mt: 5 }} />
       </div>

--- a/client/src/routes/RRHistPage.jsx
+++ b/client/src/routes/RRHistPage.jsx
@@ -8,6 +8,7 @@ import { AuthContext } from "../context/authContext";
 import UserFinder from "../apis/UserFinder";
 import RRHistory from "../components/RRHistory.component";
 import { CircularProgress } from "@mui/material";
+import RefAppBar from "../components/RetiredRefReporterAppBar";
 
 const RRHistPage = () => {
   const navigate = useNavigate();
@@ -66,7 +67,7 @@ const RRHistPage = () => {
   else if(user.role == "Reporter" || user.role == "Retired Referee"){
     return (
       <div>
-        <ResponsiveAppBar/>
+        <RefAppBar/>
         <RRHistory/>
         <Copyright sx={{ mt: 5 }} />
       </div>


### PR DESCRIPTION
fix: changed broken appbar to referee appbar in history and match detail pages

This fixes broken behavior  of user navigation to admin pages from the top and not being able to see relevent pages for himself/herself.